### PR TITLE
心跳事件与API文档描述不一致问题

### DIFF
--- a/src/main/java/io/github/imfangs/dify/client/impl/DefaultDifyClient.java
+++ b/src/main/java/io/github/imfangs/dify/client/impl/DefaultDifyClient.java
@@ -2,8 +2,10 @@ package io.github.imfangs.dify.client.impl;
 
 import io.github.imfangs.dify.client.DifyClient;
 import io.github.imfangs.dify.client.callback.*;
+import io.github.imfangs.dify.client.enums.EventType;
 import io.github.imfangs.dify.client.enums.ResponseMode;
 import io.github.imfangs.dify.client.event.BaseEvent;
+import io.github.imfangs.dify.client.event.PingEvent;
 import io.github.imfangs.dify.client.exception.DifyApiException;
 import io.github.imfangs.dify.client.model.chat.*;
 import io.github.imfangs.dify.client.model.common.SimpleResponse;
@@ -419,6 +421,11 @@ public class DefaultDifyClient extends DifyBaseClientImpl implements DifyClient 
                 log.error("解析事件数据失败: {}", data, e);
                 callback.onException(e);
             }
+        }else if ("event: ping".equalsIgnoreCase(line)){
+            // 心跳事件与dify API文档中描述不一致，返回的不是data开头
+            PingEvent pingEvent = new PingEvent();
+            pingEvent.setEvent(EventType.PING.getValue());
+            callback.onPing(pingEvent);
         }
         return true; // 继续处理
     }


### PR DESCRIPTION
心跳事件与dify API文档中描述不一致，返回的不是data开头
<img width="295" alt="image" src="https://github.com/user-attachments/assets/c00d3361-34c5-4ba6-a76b-79f502cfe9a0" />
