### PR TITLE
feat(dify-java-client):增加消息列表响应中的父消息 ID 和状态信息

### DIFF
--- a/src/main/java/io/github/imfangs/dify/client/model/chat/MessageListResponse.java
+++ b/src/main/java/io/github/imfangs/dify/client/model/chat/MessageListResponse.java
@@ -51,6 +51,10 @@ public class MessageListResponse {
          * 会话 ID
          */
         private String conversationId;
+        /**
+         * 父消息ID
+         */
+        private String parentMessageId;
 
         /**
          * 用户输入参数
@@ -91,6 +95,16 @@ public class MessageListResponse {
          * 创建时间
          */
         private Long createdAt;
+
+        /**
+         * 状态
+         */
+        private String status;
+
+        /**
+         * 错误信息
+         */
+        private String error;
     }
 
     /**


### PR DESCRIPTION
- 在 MessageListResponse 类中添加 parentMessageId 字段，用于表示父消息 ID
- 添加 status 字段，用于表示消息的状态
- 添加 error 字段，用于存储错误信息