### PR TITLE
fix(client): 修复文件上传配置字段命名问题

### DIFF
--- a/src/main/java/io/github/imfangs/dify/client/model/chat/AppParametersResponse.java
+++ b/src/main/java/io/github/imfangs/dify/client/model/chat/AppParametersResponse.java
@@ -1,6 +1,7 @@
 package io.github.imfangs.dify.client.model.chat;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -138,6 +139,10 @@ public class AppParametersResponse {
          */
         private Image image;
         /**
+         * 是否启用文件上传功能
+         */
+        private Boolean enabled;
+        /**
          * 允许的文件类型
          */
         private List<String> allowedFileTypes;
@@ -155,7 +160,9 @@ public class AppParametersResponse {
         private Integer numberLimits;
         /**
          * 文件上传配置
+         * dify该字段返回为驼峰命名 导致 获取数据失败
          */
+        @JsonProperty("fileUploadConfig")
         private FileUploadConfig fileUploadConfig;
 
         @Data

--- a/src/main/java/io/github/imfangs/dify/client/model/chat/MessageListResponse.java
+++ b/src/main/java/io/github/imfangs/dify/client/model/chat/MessageListResponse.java
@@ -1,6 +1,7 @@
 package io.github.imfangs.dify.client.model.chat;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -120,11 +121,31 @@ public class MessageListResponse {
          * 文件 ID
          */
         private String id;
+        /**
+         * 文件名
+         */
+        @JsonProperty("filename")
+        private String fileName;
 
         /**
          * 文件类型
          */
         private String type;
+
+        /**
+         * 文件 MIME 类型
+         */
+        private String mimeType;
+
+        /**
+         * 文件上传方式 remote_url/local_file
+         */
+        private String transferMethod;
+
+        /**
+         * 文件大小 字节
+         */
+        private Long size;
 
         /**
          * 文件 URL


### PR DESCRIPTION
- 在 AppParametersResponse 类中，为 fileUploadConfig 字段添加 @JsonProperty 注解- 注解值设为 "fileUploadConfig"，以匹配 Dify API 返回的 JSON 字段
- 该修复确保了文件上传配置数据能够正确映射到 Java 对象中