### PR TITLE
improve datasets process rule

### DIFF
--- a/src/main/java/io/github/imfangs/dify/client/model/datasets/ProcessRule.java
+++ b/src/main/java/io/github/imfangs/dify/client/model/datasets/ProcessRule.java
@@ -46,6 +46,13 @@ public class ProcessRule {
         private Segmentation segmentation;
 
         /**
+         * 父分段的召回模式
+         * full-doc 全文召回
+         * paragraph 段落召回
+         */
+        private String parentMode;
+
+        /**
          * 子分段规则
          */
         private SubchunkSegmentation subchunkSegmentation;
@@ -89,18 +96,6 @@ public class ProcessRule {
          * 最大长度（token）默认为 1000
          */
         private Integer maxTokens;
-
-        /**
-         * 父分段的召回模式
-         * full-doc 全文召回
-         * paragraph 段落召回
-         */
-        private String parentMode;
-
-        /**
-         * 分段重叠
-         */
-        private Integer chunkOverlap;
     }
 
     /**
@@ -120,5 +115,10 @@ public class ProcessRule {
          * 最大长度 (token) 需要校验小于父级的长度
          */
         private Integer maxTokens;
+
+        /**
+         * 分段重叠
+         */
+        private Integer chunkOverlap;
     }
 }


### PR DESCRIPTION
针对issue#33，对齐父子分段的参数，规避参数问题导致的创建文档使用默认分段模式