### PR TITLE
fix: issue#45

### DIFF
--- a/src/test/java/io/github/imfangs/dify/client/DifyChatflowClientTest.java
+++ b/src/test/java/io/github/imfangs/dify/client/DifyChatflowClientTest.java
@@ -54,7 +54,7 @@ public class DifyChatflowClientTest {
     public void testSendChatMessage() throws Exception {
         // 创建聊天消息
         ChatMessage message = ChatMessage.builder()
-                .query("你好，请介绍一下自己")
+                .query("介绍一下自己")
                 .user(USER_ID)
                 .responseMode(ResponseMode.BLOCKING)
                 .build();
@@ -67,6 +67,16 @@ public class DifyChatflowClientTest {
         assertNotNull(response.getMessageId());
         assertNotNull(response.getAnswer());
         System.out.println("回复: " + response.getAnswer());
+
+        // 测试历史会话，需要开启记忆+记忆窗口功能
+        message.setConversationId(response.getConversationId());
+        message.setQuery("我上一步问了什么?");
+        response = chatWorkflowClient.sendChatMessage(message);
+        assertNotNull(response);
+        assertNotNull(response.getMessageId());
+        assertNotNull(response.getAnswer());
+        System.out.println("回复: " + response.getAnswer());
+
     }
 
     /**


### PR DESCRIPTION

# 步骤
打开dify中记忆及窗口功能，最好用chatflow更加灵活
![image](https://github.com/user-attachments/assets/a90fd365-b69c-4d44-a1e4-661103866041)

接口发送消息时，设置conversion_id
``` java
        // 测试历史会话，需要开启记忆+记忆窗口功能
        message.setConversationId(response.getConversationId());
        message.setQuery("我上一步问了什么?");
        response = chatWorkflowClient.sendChatMessage(message);

```

效果
```
回复: 您好！很高兴认识您。

我是一个**大型语言模型**，由 **Google** 训练。

我的主要任务是：

*   理解并回应您的提问和需求。
*   提供信息、回答各种问题。
*   帮助您进行写作、翻译、总结或创作新的文本。
*   进行逻辑推理，提供建议或解决方案（在我的知识范围内）。

我没有个人经历、情感或意识，我只是一个工具，旨在通过处理和生成文本来协助您。

您可以随时向我提问或发起对话。有什么我可以帮您的吗？
回复: 您上一步问了两个问题：

1.  **我上一步问了什么?**
2.  **介绍一下自己**

我已经在上一步回复了您关于“介绍一下自己”的问题。
```