### PR TITLE
feat:增加支持Dify1.3.1版本后的标注功能模块接口！

### DIFF
--- a/src/main/java/io/github/imfangs/dify/client/DifyChatClient.java
+++ b/src/main/java/io/github/imfangs/dify/client/DifyChatClient.java
@@ -20,7 +20,7 @@ public interface DifyChatClient extends DifyBaseClient {
      *
      * @param message 消息
      * @return 响应
-     * @throws IOException IO异常
+     * @throws IOException      IO异常
      * @throws DifyApiException API异常
      */
     ChatMessageResponse sendChatMessage(ChatMessage message) throws IOException, DifyApiException;
@@ -31,7 +31,7 @@ public interface DifyChatClient extends DifyBaseClient {
      *
      * @param message  消息
      * @param callback 回调
-     * @throws IOException IO异常
+     * @throws IOException      IO异常
      * @throws DifyApiException API异常
      */
     void sendChatMessageStream(ChatMessage message, ChatStreamCallback callback) throws IOException, DifyApiException;
@@ -42,7 +42,7 @@ public interface DifyChatClient extends DifyBaseClient {
      * @param taskId 任务 ID
      * @param user   用户标识
      * @return 响应
-     * @throws IOException IO异常
+     * @throws IOException      IO异常
      * @throws DifyApiException API异常
      */
     SimpleResponse stopChatMessage(String taskId, String user) throws IOException, DifyApiException;
@@ -55,7 +55,7 @@ public interface DifyChatClient extends DifyBaseClient {
      * @param user      用户标识
      * @param content   内容
      * @return 响应
-     * @throws IOException IO异常
+     * @throws IOException      IO异常
      * @throws DifyApiException API异常
      */
     SimpleResponse feedbackMessage(String messageId, String rating, String user, String content) throws IOException, DifyApiException;
@@ -66,7 +66,7 @@ public interface DifyChatClient extends DifyBaseClient {
      * @param messageId 消息 ID
      * @param user      用户标识
      * @return 响应
-     * @throws IOException IO异常
+     * @throws IOException      IO异常
      * @throws DifyApiException API异常
      */
     SuggestedQuestionsResponse getSuggestedQuestions(String messageId, String user) throws IOException, DifyApiException;
@@ -79,7 +79,7 @@ public interface DifyChatClient extends DifyBaseClient {
      * @param firstId        当前页第一条聊天记录的 ID
      * @param limit          一次请求返回多少条聊天记录
      * @return 响应
-     * @throws IOException IO异常
+     * @throws IOException      IO异常
      * @throws DifyApiException API异常
      */
     MessageListResponse getMessages(String conversationId, String user, String firstId, Integer limit) throws IOException, DifyApiException;
@@ -92,7 +92,7 @@ public interface DifyChatClient extends DifyBaseClient {
      * @param limit  一次请求返回多少条记录
      * @param sortBy 排序字段
      * @return 响应
-     * @throws IOException IO异常
+     * @throws IOException      IO异常
      * @throws DifyApiException API异常
      */
     ConversationListResponse getConversations(String user, String lastId, Integer limit, String sortBy) throws IOException, DifyApiException;
@@ -103,7 +103,7 @@ public interface DifyChatClient extends DifyBaseClient {
      * @param conversationId 会话 ID
      * @param user           用户标识
      * @return 响应
-     * @throws IOException IO异常
+     * @throws IOException      IO异常
      * @throws DifyApiException API异常
      */
     SimpleResponse deleteConversation(String conversationId, String user) throws IOException, DifyApiException;
@@ -116,7 +116,7 @@ public interface DifyChatClient extends DifyBaseClient {
      * @param autoGenerate   自动生成标题
      * @param user           用户标识
      * @return 响应
-     * @throws IOException IO异常
+     * @throws IOException      IO异常
      * @throws DifyApiException API异常
      */
     Conversation renameConversation(String conversationId, String name, Boolean autoGenerate, String user) throws IOException, DifyApiException;
@@ -127,7 +127,7 @@ public interface DifyChatClient extends DifyBaseClient {
      * @param file 文件
      * @param user 用户标识
      * @return 响应
-     * @throws IOException IO异常
+     * @throws IOException      IO异常
      * @throws DifyApiException API异常
      */
     AudioToTextResponse audioToText(File file, String user) throws IOException, DifyApiException;
@@ -139,7 +139,7 @@ public interface DifyChatClient extends DifyBaseClient {
      * @param fileName    文件名
      * @param user        用户标识
      * @return 响应
-     * @throws IOException IO异常
+     * @throws IOException      IO异常
      * @throws DifyApiException API异常
      */
     AudioToTextResponse audioToText(InputStream inputStream, String fileName, String user) throws IOException, DifyApiException;
@@ -151,7 +151,7 @@ public interface DifyChatClient extends DifyBaseClient {
      * @param text      文本
      * @param user      用户标识
      * @return 音频数据
-     * @throws IOException IO异常
+     * @throws IOException      IO异常
      * @throws DifyApiException API异常
      */
     byte[] textToAudio(String messageId, String text, String user) throws IOException, DifyApiException;
@@ -160,9 +160,76 @@ public interface DifyChatClient extends DifyBaseClient {
      * 获取应用元数据
      *
      * @return 响应
-     * @throws IOException IO异常
+     * @throws IOException      IO异常
      * @throws DifyApiException API异常
      */
     AppMetaResponse getAppMeta() throws IOException, DifyApiException;
 
+    /**
+     * 获取标注列表
+     *
+     * @param page  页码
+     * @param limit 每页数量
+     * @return 响应
+     * @throws IOException      IO异常
+     * @throws DifyApiException API异常
+     */
+    AnnotationListResponse getAnnotations(Integer page, Integer limit) throws IOException, DifyApiException;
+
+    /**
+     * 创建标注
+     *
+     * @param question 问题
+     * @param answer   答案内容
+     * @return 标注
+     * @throws IOException      IO异常
+     * @throws DifyApiException API异常
+     */
+    Annotation saveAnnotation(String question, String answer) throws IOException, DifyApiException;
+
+    /**
+     * 更新标注
+     *
+     * @param annotationId 标注 ID
+     * @param question     问题
+     * @param answer       答案内容
+     * @return 标注
+     * @throws IOException      IO异常
+     * @throws DifyApiException API异常
+     */
+    Annotation updateAnnotation(String annotationId, String question, String answer) throws IOException, DifyApiException;
+
+    /**
+     * 删除标注
+     *
+     * @param annotationId 标注 ID
+     * @return 响应
+     * @throws IOException      IO异常
+     * @throws DifyApiException API异常
+     */
+    SimpleResponse deleteAnnotation(String annotationId) throws IOException, DifyApiException;
+
+    /**
+     * 标注回复初始设置
+     *
+     * @param action                动作，只能是 'enable' 或 'disable'
+     * @param embeddingProviderName 指定的嵌入模型提供商, 必须先在系统内设定好接入的模型，对应的是provider字段
+     * @param embeddingModelName    指定的嵌入模型，对应的是model字段
+     * @param scoreThreshold        相似度阈值，当相似度大于该阈值时，系统会自动回复，否则不回复
+     * @return 标注回复
+     * @throws IOException      IO异常
+     * @throws DifyApiException API异常
+     */
+    AnnotationReply annotationReply(String action, String embeddingProviderName, String embeddingModelName, Integer scoreThreshold) throws IOException, DifyApiException;
+
+    /**
+     * 查询标注回复初始设置任务状态
+     *
+     * @param action 动作，只能是 'enable' 或 'disable'，并且必须和标注回复初始设置接口的动作一致
+     * @param jobId  任务 ID，从标注回复初始设置接口返回的 jobId
+     * @return 标注回复
+     * @throws IOException      IO异常
+     * @throws DifyApiException API异常
+     */
+    AnnotationReply getAnnotationReply(String action, String jobId) throws IOException, DifyApiException;
 }

--- a/src/main/java/io/github/imfangs/dify/client/model/chat/Annotation.java
+++ b/src/main/java/io/github/imfangs/dify/client/model/chat/Annotation.java
@@ -1,0 +1,45 @@
+package io.github.imfangs.dify.client.model.chat;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 标注
+ *
+ * @author zhangriguang
+ * @date 2025-05-09
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Annotation {
+    /**
+     * 标注 ID
+     */
+    private String id;
+
+    /**
+     * 问题
+     */
+    private String question;
+
+    /**
+     * 答案内容
+     */
+    private String answer;
+
+    /**
+     * 命中次数
+     */
+    private Integer hitCount;
+
+    /**
+     * 创建时间
+     */
+    private Long createdAt;
+}

--- a/src/main/java/io/github/imfangs/dify/client/model/chat/AnnotationListResponse.java
+++ b/src/main/java/io/github/imfangs/dify/client/model/chat/AnnotationListResponse.java
@@ -1,0 +1,45 @@
+package io.github.imfangs.dify.client.model.chat;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * 标注列表响应
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AnnotationListResponse {
+
+    /**
+     * 返回条数
+     */
+    private Integer limit;
+
+    /**
+     * 是否存在下一页
+     */
+    private Boolean hasMore;
+
+    /**
+     * 当前页码
+     */
+    private Integer page;
+
+    /**
+     * 总数
+     */
+    private Integer total;
+
+    /**
+     * 标注列表
+     */
+    private List<Annotation> data;
+}

--- a/src/main/java/io/github/imfangs/dify/client/model/chat/AnnotationReply.java
+++ b/src/main/java/io/github/imfangs/dify/client/model/chat/AnnotationReply.java
@@ -1,0 +1,35 @@
+package io.github.imfangs.dify.client.model.chat;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 标注回复
+ *
+ * @author zhangriguang
+ * @date 2025-05-09
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AnnotationReply {
+    /**
+     * 任务 ID
+     */
+    private String jobId;
+
+    /**
+     * 任务状态
+     */
+    private String jobStatus;
+
+    /**
+     * 错误信息
+     */
+    private String errorMsg;
+}

--- a/src/test/java/io/github/imfangs/dify/client/DifyBaseClientTest.java
+++ b/src/test/java/io/github/imfangs/dify/client/DifyBaseClientTest.java
@@ -2,9 +2,8 @@ package io.github.imfangs.dify.client;
 
 import io.github.imfangs.dify.client.config.DifyTestConfig;
 import io.github.imfangs.dify.client.model.DifyConfig;
-import io.github.imfangs.dify.client.model.chat.AppInfoResponse;
-import io.github.imfangs.dify.client.model.chat.AppMetaResponse;
-import io.github.imfangs.dify.client.model.chat.AppParametersResponse;
+import io.github.imfangs.dify.client.model.chat.*;
+import io.github.imfangs.dify.client.model.common.SimpleResponse;
 import io.github.imfangs.dify.client.model.file.FileUploadRequest;
 import io.github.imfangs.dify.client.model.file.FileUploadResponse;
 import okhttp3.MediaType;
@@ -14,6 +13,8 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * Dify 基础客户端测试类
@@ -131,6 +132,99 @@ public class DifyBaseClientTest {
         try (DifyClient client = DifyClientFactory.createClient(config)) {
             AppInfoResponse appInfo = client.getAppInfo();
             System.out.println("应用信息: " + appInfo);
+        }
+    }
+
+    /**
+     * 测试获取标注列表
+     */
+    @Test
+    public void testGetAnnotations() throws Exception {
+        try (DifyClient client = DifyClientFactory.createClient(BASE_URL, API_KEY)) {
+            int page = 1;
+            int limit = 10;
+            AnnotationListResponse list = client.getAnnotations(page, limit);
+            System.out.println("标注列表数据: " + list);
+        }
+    }
+
+    /**
+     * 测试创建标注
+     */
+    @Test
+    public void testSaveAnnotation() throws Exception {
+        try (DifyClient client = DifyClientFactory.createClient(BASE_URL, API_KEY)) {
+            String question = "创建你的问题";
+            String answer = "创建问题回答";
+            Annotation annotation = client.saveAnnotation(question, answer);
+            System.out.println("保存标注数据: " + annotation);
+        }
+    }
+
+    /**
+     * 测试更新标注
+     */
+    @Test
+    public void testUpdateAnnotation() throws Exception {
+        try (DifyClient client = DifyClientFactory.createClient(BASE_URL, API_KEY)) {
+            int page = 1;
+            int limit = 1;
+            AnnotationListResponse list = client.getAnnotations(page, limit);
+            List<Annotation> data = list.getData();
+            if(Objects.nonNull(data)) {
+                String  annotationId = data.get(0).getId();
+                String question = "更新你的问题";
+                String answer = "更新问题回答";
+                Annotation annotation = client.updateAnnotation(annotationId, question, answer);
+                System.out.println("更新标注数据: " + annotation);
+            }
+        }
+    }
+
+    /**
+     * 测试删除标注
+     */
+    @Test
+    public void testDeleteAnnotation() throws Exception {
+        try (DifyClient client = DifyClientFactory.createClient(BASE_URL, API_KEY)) {
+            int page = 1;
+            int limit = 1;
+            AnnotationListResponse list = client.getAnnotations(page, limit);
+            List<Annotation> data = list.getData();
+            if(Objects.nonNull(data)) {
+                String  annotationId = data.get(0).getId();
+                SimpleResponse response = client.deleteAnnotation(annotationId);
+                System.out.println("删除标注数据: " + response);
+            }
+        }
+    }
+
+    /**
+     * 测试标注回复初始设置
+     */
+    @Test
+    public void testAnnotationReply() throws Exception {
+        try (DifyClient client = DifyClientFactory.createClient(BASE_URL, API_KEY)) {
+            String action = "enable";
+            String embeddingProviderName = "指定的嵌入模型提供商";
+            String embeddingModelName = "指定的嵌入模型";
+            Integer scoreThreshold = 10;
+            AnnotationReply annotationReply = client.annotationReply(action, embeddingProviderName, embeddingModelName, scoreThreshold);
+            System.out.println("标注回复初始设置数据: " + annotationReply);
+
+        }
+    }
+
+    /**
+     * 测试查询标注回复初始设置任务状态
+     */
+    @Test
+    public void testGetAnnotationReply() throws Exception {
+        try (DifyClient client = DifyClientFactory.createClient(BASE_URL, API_KEY)) {
+            String action = "disable";
+            String jobId = "任务 ID";
+            AnnotationReply annotationReply = client.getAnnotationReply(action, jobId);
+            System.out.println("查询标注回复初始设置任务状态数据: " + annotationReply);
         }
     }
 }


### PR DESCRIPTION
包括扩展了Dify1.3.1后的6个接口，3个实体对象：
一、接口：
1、获取标注列表：getAnnotations
2、创建标注：saveAnnotation
3、更新标注：updateAnnotation
4、删除标注：deleteAnnotation
5、标注回复初始设置：annotationReply
6、查询标注回复初始设置任务状态：getAnnotationReply
二、实体对象：
1、标注：Annotation
2、标注列表响应：AnnotationListResponse
3、标注回复：AnnotationReply
