### PR TITLE
dataset client 功能增强与错误修复

### DIFF
--- a/src/main/java/io/github/imfangs/dify/client/DifyDatasetsClient.java
+++ b/src/main/java/io/github/imfangs/dify/client/DifyDatasetsClient.java
@@ -150,7 +150,7 @@ public interface DifyDatasetsClient {
      * @throws IOException IO异常
      * @throws DifyApiException API异常
      */
-    SegmentResponse createSegments(String datasetId, String documentId, CreateSegmentsRequest request) throws IOException, DifyApiException;
+    SegmentListResponse createSegments(String datasetId, String documentId, CreateSegmentsRequest request) throws IOException, DifyApiException;
 
     /**
      * 查询文档分段

--- a/src/main/java/io/github/imfangs/dify/client/DifyDatasetsClient.java
+++ b/src/main/java/io/github/imfangs/dify/client/DifyDatasetsClient.java
@@ -122,11 +122,10 @@ public interface DifyDatasetsClient {
      *
      * @param datasetId  知识库ID
      * @param documentId 文档ID
-     * @return 响应
      * @throws IOException IO异常
      * @throws DifyApiException API异常
      */
-    SimpleResponse deleteDocument(String datasetId, String documentId) throws IOException, DifyApiException;
+    void deleteDocument(String datasetId, String documentId) throws IOException, DifyApiException;
 
     /**
      * 获取知识库文档列表
@@ -172,11 +171,10 @@ public interface DifyDatasetsClient {
      * @param datasetId  知识库ID
      * @param documentId 文档ID
      * @param segmentId  分段ID
-     * @return 响应
      * @throws IOException IO异常
      * @throws DifyApiException API异常
      */
-    SimpleResponse deleteSegment(String datasetId, String documentId, String segmentId) throws IOException, DifyApiException;
+    void deleteSegment(String datasetId, String documentId, String segmentId) throws IOException, DifyApiException;
 
     /**
      * 更新文档分段

--- a/src/main/java/io/github/imfangs/dify/client/DifyDatasetsClient.java
+++ b/src/main/java/io/github/imfangs/dify/client/DifyDatasetsClient.java
@@ -165,6 +165,21 @@ public interface DifyDatasetsClient {
      */
     SegmentListResponse getSegments(String datasetId, String documentId, String keyword, String status) throws IOException, DifyApiException;
 
+
+    /**
+     * 查询文档分段
+     * @param datasetId 知识库ID    
+     * @param documentId 文档ID
+     * @param keyword 关键词
+     * @param status 状态
+     * @param page 页码
+     * @param limit 每页数量
+     * @return 分段列表
+     * @throws IOException IO异常
+     * @throws DifyApiException API异常
+     */
+    SegmentListResponse getSegments(String datasetId, String documentId, String keyword, String status, Integer page, Integer limit) throws IOException, DifyApiException;
+
     /**
      * 删除文档分段
      *

--- a/src/main/java/io/github/imfangs/dify/client/DifyDatasetsClient.java
+++ b/src/main/java/io/github/imfangs/dify/client/DifyDatasetsClient.java
@@ -182,6 +182,8 @@ public interface DifyDatasetsClient {
 
     /**
      * 删除文档分段
+     * 
+     * 注意：官方文档写的返回 { "result": "success" } ，实际返回的是空
      *
      * @param datasetId  知识库ID
      * @param documentId 文档ID
@@ -203,6 +205,60 @@ public interface DifyDatasetsClient {
      * @throws DifyApiException API异常
      */
     SegmentResponse updateSegment(String datasetId, String documentId, String segmentId, UpdateSegmentRequest request) throws IOException, DifyApiException;
+
+
+    /**
+     * 创建子分段
+     * @param datasetId 知识库ID
+     * @param docummentId 文档ID
+     * @param segmentId 分段ID
+     * @param request 子分段请求
+     * @return 子分段信息
+     * @throws IOException IO异常
+     * @throws DifyApiException API异常
+     */
+    ChildChunkResponse createChildChunk(String datasetId, String docummentId,  String segmentId, SaveChildChunkRequest request) throws IOException, DifyApiException;
+
+    /**
+     * 获取子分段
+     * @param datasetId 知识库ID
+     * @param docummentId 文档ID
+     * @param segmentId 分段ID
+     * @param keyword 关键词
+     * @param page 页码
+     * @param limit 每页数量
+     * @return 子分段列表
+     * @throws IOException IO异常
+     * @throws DifyApiException API异常
+     */
+    ChildChunkListResponse getChildChunks(String datasetId, String docummentId, String segmentId, String keyword, Integer page, Integer limit) throws IOException, DifyApiException;
+
+
+    /**
+     * 删除子分段
+     * @param datasetId 知识库ID
+     * @param docummentId
+     * @param segmentId
+     * @param childChunkId
+     * @throws IOException IO异常
+     * @throws DifyApiException API异常
+     */
+    void deleteChildChunks(String datasetId, String docummentId, String segmentId, String childChunkId) throws IOException, DifyApiException;
+
+
+    /**
+     * 更新子分段
+     * @param datasetId 知识库ID
+     * @param docummentId 文档ID 
+     * @param segmentId 分段ID
+     * @param childChunkId 子分段ID
+     * @param request 子分段请求
+     * @return 子分段信息
+     * @throws IOException IO异常
+     * @throws DifyApiException API异常
+     */
+    ChildChunkResponse updateChildChunk(String datasetId, String docummentId, String segmentId, String childChunkId, SaveChildChunkRequest request) throws IOException, DifyApiException;
+
 
     /**
      * 获取上传文件

--- a/src/main/java/io/github/imfangs/dify/client/impl/DefaultDifyDatasetsClient.java
+++ b/src/main/java/io/github/imfangs/dify/client/impl/DefaultDifyDatasetsClient.java
@@ -155,9 +155,9 @@ public class DefaultDifyDatasetsClient extends AbstractDifyClient implements Dif
     }
 
     @Override
-    public SegmentResponse createSegments(String datasetId, String documentId, CreateSegmentsRequest request) throws IOException, DifyApiException {
+    public SegmentListResponse createSegments(String datasetId, String documentId, CreateSegmentsRequest request) throws IOException, DifyApiException {
         String path = buildDocumentPath(datasetId, documentId) + SEGMENTS_PATH;
-        return executePost(path, request, SegmentResponse.class);
+        return executePost(path, request, SegmentListResponse.class);
     }
 
     @Override

--- a/src/main/java/io/github/imfangs/dify/client/impl/DefaultDifyDatasetsClient.java
+++ b/src/main/java/io/github/imfangs/dify/client/impl/DefaultDifyDatasetsClient.java
@@ -137,9 +137,9 @@ public class DefaultDifyDatasetsClient extends AbstractDifyClient implements Dif
     }
 
     @Override
-    public SimpleResponse deleteDocument(String datasetId, String documentId) throws IOException, DifyApiException {
+    public void deleteDocument(String datasetId, String documentId) throws IOException, DifyApiException {
         String path = buildDocumentPath(datasetId, documentId);
-        return executeDelete(path, null, SimpleResponse.class);
+        executeDelete(path, null, Object.class);
     }
 
     @Override
@@ -172,9 +172,9 @@ public class DefaultDifyDatasetsClient extends AbstractDifyClient implements Dif
     }
 
     @Override
-    public SimpleResponse deleteSegment(String datasetId, String documentId, String segmentId) throws IOException, DifyApiException {
+    public void deleteSegment(String datasetId, String documentId, String segmentId) throws IOException, DifyApiException {
         String path = buildSegmentPath(datasetId, documentId, segmentId);
-        return executeDelete(path, null, SimpleResponse.class);
+        executeDelete(path, null, Object.class);
     }
 
     @Override

--- a/src/main/java/io/github/imfangs/dify/client/impl/DefaultDifyDatasetsClient.java
+++ b/src/main/java/io/github/imfangs/dify/client/impl/DefaultDifyDatasetsClient.java
@@ -162,9 +162,16 @@ public class DefaultDifyDatasetsClient extends AbstractDifyClient implements Dif
 
     @Override
     public SegmentListResponse getSegments(String datasetId, String documentId, String keyword, String status) throws IOException, DifyApiException {
+       return getSegments(datasetId, documentId, keyword, status, null, null);
+    }
+
+    @Override
+    public SegmentListResponse getSegments(String datasetId, String documentId, String keyword, String status, Integer page, Integer limit) throws IOException, DifyApiException {
         Map<String, Object> queryParams = new HashMap<>();
         addIfNotEmpty(queryParams, "keyword", keyword);
         addIfNotEmpty(queryParams, "status", status);
+        addIfNotNull(queryParams, "page", page);
+        addIfNotNull(queryParams, "limit", limit);
 
         String path = buildDocumentPath(datasetId, documentId) + SEGMENTS_PATH;
         String url = buildUrlWithParams(path, queryParams);

--- a/src/main/java/io/github/imfangs/dify/client/impl/DefaultDifyDatasetsClient.java
+++ b/src/main/java/io/github/imfangs/dify/client/impl/DefaultDifyDatasetsClient.java
@@ -19,11 +19,13 @@ import java.util.Map;
  * 提供知识库相关的操作
  */
 @Slf4j
-public class DefaultDifyDatasetsClient extends AbstractDifyClient implements DifyDatasetsClient {
+public class DefaultDifyDatasetsClient extends AbstractDifyClient implements DifyDatasetsClient { 
+   
     // API 路径常量
     private static final String DATASETS_PATH = "/datasets";
     private static final String DOCUMENTS_PATH = "/documents";
     private static final String SEGMENTS_PATH = "/segments";
+    private static final String CHILD_CHUNKS_PATH = "/child_chunks";
     private static final String DOCUMENT_CREATE_BY_TEXT_PATH = "/document/create-by-text";
     private static final String DOCUMENT_CREATE_BY_FILE_PATH = "/document/create-by-file";
     private static final String UPDATE_BY_TEXT_PATH = "/update-by-text";
@@ -191,6 +193,30 @@ public class DefaultDifyDatasetsClient extends AbstractDifyClient implements Dif
     }
 
     @Override
+    public ChildChunkResponse createChildChunk(String datasetId, String docummentId,  String segmentId, SaveChildChunkRequest request) throws IOException, DifyApiException {
+        String path = buildSegmentPath(datasetId, docummentId, segmentId) + CHILD_CHUNKS_PATH;
+        return executePost(path, request, ChildChunkResponse.class);
+    }
+
+    @Override
+    public ChildChunkListResponse getChildChunks(String datasetId, String docummentId, String segmentId, String keyword, Integer page, Integer limit) throws IOException, DifyApiException {
+        String path = buildSegmentPath(datasetId, docummentId, segmentId) + CHILD_CHUNKS_PATH;
+        return executeGet(path, ChildChunkListResponse.class);
+    }
+
+    @Override
+    public void deleteChildChunks(String datasetId, String docummentId, String segmentId, String childChunkId) throws IOException, DifyApiException {
+        String path = buildChildChunkPath(datasetId, docummentId, segmentId, childChunkId);
+        executeDelete(path, null, Object.class);
+    }
+
+    @Override
+    public ChildChunkResponse updateChildChunk(String datasetId, String docummentId, String segmentId, String childChunkId, SaveChildChunkRequest request) throws IOException, DifyApiException {
+        String path = buildChildChunkPath(datasetId, docummentId, segmentId, childChunkId);
+        return executePatch(path, request, ChildChunkResponse.class);
+    }
+
+    @Override
     public UploadFileResponse getUploadFile(String datasetId, String documentId) throws IOException, DifyApiException {
         String path = buildDocumentPath(datasetId, documentId) + UPLOAD_FILE_PATH;
         return executeGet(path, UploadFileResponse.class);
@@ -278,6 +304,11 @@ public class DefaultDifyDatasetsClient extends AbstractDifyClient implements Dif
      */
     private String buildSegmentPath(String datasetId, String documentId, String segmentId) {
         return buildDocumentPath(datasetId, documentId) + SEGMENTS_PATH + "/" + segmentId;
+    }
+
+    
+    private String buildChildChunkPath(String datasetId, String docummentId, String segmentId, String childChunkId) {
+        return buildSegmentPath(datasetId, docummentId, segmentId) + CHILD_CHUNKS_PATH + "/" + childChunkId;
     }
 
     /**

--- a/src/main/java/io/github/imfangs/dify/client/model/datasets/ChildChunkListResponse.java
+++ b/src/main/java/io/github/imfangs/dify/client/model/datasets/ChildChunkListResponse.java
@@ -1,0 +1,196 @@
+package io.github.imfangs.dify.client.model.datasets;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 子分段响应
+ * 
+ * 示例：
+ * {
+ *    "data": [{
+ *      "id": "",
+ *      "position": 1,
+ *      "document_id": "",
+ *      "content": "1",
+ *      "answer": "1",
+ *      "word_count": 25,
+ *      "tokens": 0,
+ *      "keywords": ["a"],
+ *      "index_node_id": "",
+ *      "index_node_hash": "",
+ *      "hit_count": 0,
+ *      "enabled": true,
+ *      "disabled_at": null,
+ *      "disabled_by": null,
+ *      "status": "completed",
+ *      "created_by": "",
+ *      "created_at": 1695312007,
+ *      "indexing_at": 1695312007,
+ *      "completed_at": 1695312007,
+ *      "error": null,
+ *      "stopped_at": null
+ *    }],
+ *    "doc_form": "text_model",
+ *    "has_more": false,
+ *    "limit": 20,
+ *    "total": 9,
+ *    "page": 1
+ * }
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChildChunkListResponse {
+
+  /**
+   * 子分段信息
+   */
+  private List<ChildChunk> data;
+
+  /**
+   * 文档类型
+   */
+  private String docForm;
+
+  /**
+   * 是否还有更多
+   */
+  private Boolean hasMore;
+
+  /**
+   * 每页数量
+   */
+  private Integer limit;
+
+  /**
+   * 总数
+   */
+  private Integer total;
+
+  /**
+   * 页码
+   */
+  private Integer page;
+
+  /**
+   * 子分段信息
+   */
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class ChildChunk {
+
+    /**
+     * 子分段ID
+     */
+    private String id;
+
+    /**
+     * 位置
+     */
+    private Integer position;
+
+    /**
+     * 文档ID
+     */
+    private String documentId;
+
+    /**
+     * 内容
+     */
+    private String content;
+
+    /**
+     * 答案
+     */
+    private String answer;
+
+    /**
+     * 字数
+     */
+    private Integer wordCount;
+
+    /**
+     * Token 数
+     */
+    private Integer tokens;
+
+    /**
+     * 关键词
+     * 
+     */
+     private List<String> keywords;
+
+    /**
+     * 索引节点ID
+     */
+    private String indexNodeId;
+
+    /**
+     * 索引节点哈希
+     */
+    private String indexNodeHash;
+
+    /**
+     * 命中数
+     */
+    private Integer hitCount;
+
+    /**
+     * 是否启用
+     */
+    private Boolean enabled;
+
+    /**
+     * 禁用时间
+     */
+    private Long disabledAt;
+
+    /**
+     * 禁用者
+     */
+    private String disabledBy;
+
+    /**
+     * 状态
+     */
+    private String status;
+
+    /**
+     * 创建者
+     */
+    private String createdBy;
+
+    /**
+     * 创建时间
+     */
+    private Long createdAt;
+
+    /**
+     * 索引时间
+     */
+    private Long indexingAt;
+
+    /**
+     * 完成时间
+     */
+    private Long completedAt;
+
+    /**
+     * 错误
+     */
+    private String error;
+
+    /**
+     * 停止时间
+     */
+    private Long stoppedAt;
+  }
+}

--- a/src/main/java/io/github/imfangs/dify/client/model/datasets/ChildChunkResponse.java
+++ b/src/main/java/io/github/imfangs/dify/client/model/datasets/ChildChunkResponse.java
@@ -1,0 +1,122 @@
+package io.github.imfangs.dify.client.model.datasets;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 子分段响应
+ * 
+ * 示例：
+ * {
+ *    "data": {
+ *      "id": "",
+ *      "segment_id": "",
+ *      "content": "子分段内容",
+ *      "word_count": 25,
+ *      "tokens": 0,
+ *      "index_node_id": "",
+ *      "index_node_hash": "",
+ *      "status": "completed",
+ *      "created_by": "",
+ *      "created_at": 1695312007,
+ *      "indexing_at": 1695312007,
+ *      "completed_at": 1695312007,
+ *      "error": null,
+ *      "stopped_at": null
+ *    }
+ * }
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChildChunkResponse {
+
+  /**
+   * 子分段信息
+   */
+  private ChildChunkInfo data;
+
+
+  /**
+   * 子分段信息
+   */
+  @Data
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class ChildChunkInfo {
+
+    /**
+     * 子分段ID
+     */
+    private String id;
+
+    /**
+     * 分段ID
+     */
+    private String segmentId;
+
+    /**
+     * 子分段内容
+     */
+    private String content;
+
+    /**
+     * 字数
+     */
+    private Integer wordCount;
+
+    /**
+     * Token 数
+     */
+    private Integer tokens;
+
+    /**
+     * 索引节点ID
+     */
+    private String indexNodeId;
+
+    /** 
+     * 索引节点哈希
+     */
+    private String indexNodeHash;
+
+    /**
+     * 状态
+     */
+    private String status;
+
+    /**
+     * 创建者
+     */
+    private String createdBy;
+
+    /**
+     * 创建时间
+     */
+    private Long createdAt;
+
+    /**
+     * 索引时间
+     */
+    private Long indexingAt;
+
+    /**
+     * 完成时间
+     */
+    private Long completedAt;
+
+    /**
+     * 错误
+     */
+    private String error;
+
+    /**
+     * 停止时间
+     */
+    private Long stoppedAt;
+  }
+}

--- a/src/main/java/io/github/imfangs/dify/client/model/datasets/SaveChildChunkRequest.java
+++ b/src/main/java/io/github/imfangs/dify/client/model/datasets/SaveChildChunkRequest.java
@@ -1,0 +1,21 @@
+package io.github.imfangs.dify.client.model.datasets;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 创建或者更新子分段请求
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SaveChildChunkRequest {
+  /**
+   * 子分段内容
+   */
+  private String content;
+
+}

--- a/src/main/java/io/github/imfangs/dify/client/model/datasets/SegmentResponse.java
+++ b/src/main/java/io/github/imfangs/dify/client/model/datasets/SegmentResponse.java
@@ -18,7 +18,7 @@ public class SegmentResponse {
     /**
      * 分段列表
      */
-    private List<SegmentInfo> data;
+    private SegmentInfo data;
 
     /**
      * 文档形式


### PR DESCRIPTION
1. 新增 dataset client child chunk 接口
2. 新增 DifyDatasetsClient getSegments 支持 page 和 limit 参数
3. 修复 updateSegment 函数定义的返回值类型与 API 实际返回的JSON不符，导致 Failed to convert JSON to object 错误
4. 修复 Dify 1.3.1 document 与 segment delete 接口变更导致的 Failed to convert JSON to object 错误