### PR TITLE
fix: end SSE stream on terminal events to close socket (#128)

### DIFF
--- a/src/main/java/io/github/imfangs/dify/client/impl/DefaultDifyClient.java
+++ b/src/main/java/io/github/imfangs/dify/client/impl/DefaultDifyClient.java
@@ -456,6 +456,14 @@ public class DefaultDifyClient extends DifyBaseClientImpl implements DifyClient 
 
                 // 处理事件
                 eventProcessor.process(data, baseEvent.getEvent());
+                // 如果是结束类事件，则停止继续读取，主动关闭连接
+                String eventTypeStr = baseEvent.getEvent();
+                EventType eventType = eventTypeStr != null ? EventType.fromValue(eventTypeStr) : null;
+                if (eventType == EventType.MESSAGE_END
+                        || eventType == EventType.WORKFLOW_FINISHED
+                        || eventType == EventType.ERROR) {
+                    return false;
+                }
             } catch (Exception e) {
                 log.error("解析事件数据失败: {}", data, e);
                 callback.onException(e);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Stop SSE stream processing on MESSAGE_END, WORKFLOW_FINISHED, or ERROR events to close the socket.
> 
> - **Streaming SSE handling (`DefaultDifyClient.processStreamLine`)**:
>   - After dispatching events, detect terminal event types (`MESSAGE_END`, `WORKFLOW_FINISHED`, `ERROR`) and return `false` to stop reading and close the connection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3f9887cf7a5a078dc55b4e6f2c6c0daeb93c200. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->