### PR TITLE
fix: ensure message_end is received in Chatflow mode

### DIFF
--- a/src/main/java/io/github/imfangs/dify/client/impl/DefaultDifyClient.java
+++ b/src/main/java/io/github/imfangs/dify/client/impl/DefaultDifyClient.java
@@ -491,7 +491,6 @@ public class DefaultDifyClient extends DifyBaseClientImpl implements DifyClient 
                 String eventTypeStr = baseEvent.getEvent();
                 EventType eventType = eventTypeStr != null ? EventType.fromValue(eventTypeStr) : null;
                 if (eventType == EventType.MESSAGE_END
-                        || eventType == EventType.WORKFLOW_FINISHED
                         || eventType == EventType.ERROR) {
                     return false;
                 }


### PR DESCRIPTION
fix: keep reading after workflow_finished to capture message_end

- remove WORKFLOW_FINISHED from early-break condition
- set readTimeout=0 for SSE to avoid SocketTimeoutException