### PR TITLE
fix: 添加conversation_id字段到BaseWorkflowEvent (修复 #145)

### DIFF
--- a/src/main/java/io/github/imfangs/dify/client/event/BaseWorkflowEvent.java
+++ b/src/main/java/io/github/imfangs/dify/client/event/BaseWorkflowEvent.java
@@ -18,4 +18,10 @@ public abstract class BaseWorkflowEvent extends BaseEvent {
      */
     @JsonProperty("workflow_run_id")
     private String workflowRunId;
+
+    /**
+     * 会话ID（对话型应用特有）
+     */
+    @JsonProperty("conversation_id")
+    private String conversationId;
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `conversation_id` to `BaseWorkflowEvent` to carry session context for conversational apps.
> 
> - Introduces `conversationId` with `@JsonProperty("conversation_id")` alongside existing `workflow_run_id`
> - Touches only `BaseWorkflowEvent.java`; no other logic or files modified
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b97473b1dbc20030e17b25c3d5cd75b1ada590e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->