### PR TITLE
fix: Add chunkOverlap field to ProcessRule class

### DIFF
--- a/src/main/java/io/github/imfangs/dify/client/model/datasets/ProcessRule.java
+++ b/src/main/java/io/github/imfangs/dify/client/model/datasets/ProcessRule.java
@@ -97,6 +97,11 @@ public class ProcessRule {
          * 最大长度（token）默认为 1000
          */
         private Integer maxTokens;
+        
+        /**
+         * 分段重叠
+         */
+        private Integer chunkOverlap;
     }
 
     /**


### PR DESCRIPTION
In Dify's text general segmentation rules, it actually supports segmentation parameters such as `separator` `max_tokens` `chunk_overlap`, which are the same as the parameters for setting segmentation rules in Dify pages.

<img width="1030" height="504" alt="image" src="https://github.com/user-attachments/assets/a3e65334-f9f4-46ef-a4a4-91fef5df28df" />

 During actual testing, it is also supported through the interface to control via this attribute. It is hoped to add this, so that the segmentation overlap can also be set through the API.


Here is the `Segmentation` model class in the Dify source code: [class Segmentation](https://github.com/langgenius/dify/blob/main/api/services/entities/knowledge_entities/knowledge_entities.py#L60-L64)