### PR TITLE
fix(stream): preserve Chatflow terminal events and completion

### DIFF
--- a/src/main/java/io/github/imfangs/dify/client/callback/BaseStreamCallback.java
+++ b/src/main/java/io/github/imfangs/dify/client/callback/BaseStreamCallback.java
@@ -33,4 +33,13 @@ public interface BaseStreamCallback {
     default void onException(Throwable throwable) {
     }
 
+    /**
+     * SDK 已完成对 SSE 响应的读取。
+     *
+     * <p>当收到客户端定义的终止事件，或服务端正常关闭 SSE 连接时触发。该回调仅表示协议流读取结束，
+     * 不表示 Dify 工作流或调用方业务处理成功。Dify {@code error} 事件和网络异常不会触发该回调。</p>
+     */
+    default void onStreamComplete() {
+    }
+
 }

--- a/src/main/java/io/github/imfangs/dify/client/impl/AbstractDifyClient.java
+++ b/src/main/java/io/github/imfangs/dify/client/impl/AbstractDifyClient.java
@@ -492,6 +492,23 @@ public abstract class AbstractDifyClient {
     }
 
     /**
+     * 带结束原因的行处理器。
+     */
+    @FunctionalInterface
+    protected interface StreamLineProcessor {
+        StreamLineResult process(String line);
+    }
+
+    /**
+     * SSE 行处理结果。
+     */
+    protected enum StreamLineResult {
+        CONTINUE,
+        COMPLETE,
+        ERROR
+    }
+
+    /**
      * 事件处理器
      */
     @FunctionalInterface
@@ -515,6 +532,25 @@ public abstract class AbstractDifyClient {
     }
 
     /**
+     * 执行 POST 流式请求，并在正常结束时通知调用方。
+     */
+    protected void executeStreamRequest(String path,
+                                        Object body,
+                                        StreamLineProcessor lineProcessor,
+                                        Consumer<Exception> errorHandler,
+                                        Runnable completionHandler) {
+        RequestBody requestBody = createJsonRequestBody(body);
+        Request httpRequest = new Request.Builder()
+                .url(baseUrl + path)
+                .post(requestBody)
+                .header("Authorization", "Bearer " + apiKey)
+                .header("Content-Type", "application/json")
+                .header("Accept", "text/event-stream")
+                .build();
+        executeStreamCall(httpRequest, lineProcessor, errorHandler, completionHandler);
+    }
+
+    /**
      * 执行 GET 流式请求
      */
     protected void executeGetStreamRequest(String path, LineProcessor lineProcessor, Consumer<Exception> errorHandler) {
@@ -527,7 +563,33 @@ public abstract class AbstractDifyClient {
         executeStreamCall(httpRequest, lineProcessor, errorHandler);
     }
 
+    /**
+     * 执行 GET 流式请求，并在正常结束时通知调用方。
+     */
+    protected void executeGetStreamRequest(String path,
+                                           StreamLineProcessor lineProcessor,
+                                           Consumer<Exception> errorHandler,
+                                           Runnable completionHandler) {
+        Request httpRequest = new Request.Builder()
+                .url(baseUrl + path)
+                .get()
+                .header("Authorization", "Bearer " + apiKey)
+                .header("Accept", "text/event-stream")
+                .build();
+        executeStreamCall(httpRequest, lineProcessor, errorHandler, completionHandler);
+    }
+
     protected void executeStreamCall(Request httpRequest, LineProcessor lineProcessor, Consumer<Exception> errorHandler) {
+        executeStreamCall(httpRequest,
+                line -> lineProcessor.process(line) ? StreamLineResult.CONTINUE : StreamLineResult.COMPLETE,
+                errorHandler,
+                null);
+    }
+
+    protected void executeStreamCall(Request httpRequest,
+                                     StreamLineProcessor lineProcessor,
+                                     Consumer<Exception> errorHandler,
+                                     Runnable completionHandler) {
         Call call = httpClient.newCall(httpRequest);
         call.enqueue(new Callback() {
             @Override
@@ -561,13 +623,23 @@ public abstract class AbstractDifyClient {
 
                     try (BufferedReader reader = new BufferedReader(new InputStreamReader(responseBody.byteStream(), StandardCharsets.UTF_8))) {
                         String line;
+                        boolean receivedErrorEvent = false;
                         while ((line = reader.readLine()) != null) {
                             if (line.isEmpty()) {
                                 continue;
                             }
-                            if (!lineProcessor.process(line)) {
+
+                            StreamLineResult result = lineProcessor.process(line);
+                            if (result == StreamLineResult.ERROR) {
+                                receivedErrorEvent = true;
                                 break;
                             }
+                            if (result == StreamLineResult.COMPLETE) {
+                                break;
+                            }
+                        }
+                        if (!receivedErrorEvent && completionHandler != null) {
+                            completionHandler.run();
                         }
                     }
                 } catch (Exception e) {
@@ -582,8 +654,18 @@ public abstract class AbstractDifyClient {
      * 处理一行 SSE 数据
      */
     protected boolean processStreamLine(String line, BaseStreamCallback callback, Set<EventType> terminalEvents, EventProcessor eventProcessor) {
+        return processStreamLineWithResult(line, callback, terminalEvents, eventProcessor) == StreamLineResult.CONTINUE;
+    }
+
+    /**
+     * 处理一行 SSE 数据，并保留结束原因。
+     */
+    protected StreamLineResult processStreamLineWithResult(String line,
+                                                           BaseStreamCallback callback,
+                                                           Set<EventType> terminalEvents,
+                                                           EventProcessor eventProcessor) {
         if (line == null || line.trim().isEmpty()) {
-            return true;
+            return StreamLineResult.CONTINUE;
         }
         if (line.startsWith(STREAM_DATA_PREFIX)) {
             String data = line.substring(STREAM_DATA_PREFIX.length()).trim();
@@ -591,13 +673,16 @@ public abstract class AbstractDifyClient {
                 BaseEvent baseEvent = JsonUtils.fromJson(data, BaseEvent.class);
                 if (baseEvent == null) {
                     log.warn("解析事件数据为null: {}", data);
-                    return true;
+                    return StreamLineResult.CONTINUE;
                 }
                 eventProcessor.process(data, baseEvent.getEvent());
                 String eventTypeStr = baseEvent.getEvent();
                 EventType eventType = eventTypeStr != null ? EventType.fromValue(eventTypeStr) : null;
+                if (eventType == EventType.ERROR) {
+                    return StreamLineResult.ERROR;
+                }
                 if (eventType != null && terminalEvents.contains(eventType)) {
-                    return false;
+                    return StreamLineResult.COMPLETE;
                 }
             } catch (Exception e) {
                 log.error("解析事件数据失败: {}", data, e);
@@ -608,6 +693,6 @@ public abstract class AbstractDifyClient {
             pingEvent.setEvent(EventType.PING.getValue());
             callback.onPing(pingEvent);
         }
-        return true;
+        return StreamLineResult.CONTINUE;
     }
 }

--- a/src/main/java/io/github/imfangs/dify/client/impl/DefaultDifyClient.java
+++ b/src/main/java/io/github/imfangs/dify/client/impl/DefaultDifyClient.java
@@ -18,6 +18,7 @@ import okhttp3.*;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
@@ -33,8 +34,9 @@ import java.util.function.Consumer;
 public class DefaultDifyClient extends DifyBaseClientImpl implements DifyClient {
 
     // 流式响应相关常量
-    private static final Set<EventType> CHAT_TERMINAL_EVENTS = EnumSet.of(EventType.MESSAGE_END, EventType.ERROR);
-    private static final Set<EventType> WORKFLOW_TERMINAL_EVENTS = EnumSet.of(EventType.WORKFLOW_FINISHED, EventType.ERROR);
+    private static final Set<EventType> CHAT_TERMINAL_EVENTS = EnumSet.of(EventType.MESSAGE_END);
+    private static final Set<EventType> NO_TERMINAL_EVENTS = Collections.emptySet();
+    private static final Set<EventType> WORKFLOW_TERMINAL_EVENTS = EnumSet.of(EventType.WORKFLOW_FINISHED);
 
     // API 路径常量
     // 对话型应用相关路径
@@ -111,9 +113,9 @@ public class DefaultDifyClient extends DifyBaseClientImpl implements DifyClient 
         message.setResponseMode(ResponseMode.STREAMING);
 
         // 执行流式请求
-        executeStreamRequest(CHAT_MESSAGES_PATH, message, (line) -> processStreamLine(line, callback, CHAT_TERMINAL_EVENTS, (data, eventType) -> {
+        executeStreamRequest(CHAT_MESSAGES_PATH, message, (line) -> processStreamLineWithResult(line, callback, CHAT_TERMINAL_EVENTS, (data, eventType) -> {
             StreamEventDispatcher.dispatchChatEvent(callback, data, eventType);
-        }), callback::onException);
+        }), callback::onException, callback::onStreamComplete);
     }
 
     @Override
@@ -122,10 +124,19 @@ public class DefaultDifyClient extends DifyBaseClientImpl implements DifyClient 
         // 确保请求模式为流式
         message.setResponseMode(ResponseMode.STREAMING);
 
-        // 执行流式请求
-        executeStreamRequest(CHAT_MESSAGES_PATH, message, (line) -> processStreamLine(line, callback, WORKFLOW_TERMINAL_EVENTS, (data, eventType) -> {
-            StreamEventDispatcher.dispatchChatFlowEvent(callback, data, eventType);
-        }), callback::onException);
+        ChatflowTerminalState terminalState = new ChatflowTerminalState();
+        executeStreamRequest(CHAT_MESSAGES_PATH, message, (line) -> {
+            StreamLineResult result = processStreamLineWithResult(line, callback, NO_TERMINAL_EVENTS, (data, eventType) -> {
+                StreamEventDispatcher.dispatchChatFlowEvent(callback, data, eventType);
+                terminalState.record(eventType);
+            });
+            if (result != StreamLineResult.CONTINUE) {
+                return result;
+            }
+            return terminalState.hasReceivedAllTerminalEvents()
+                    ? StreamLineResult.COMPLETE
+                    : StreamLineResult.CONTINUE;
+        }, callback::onException, callback::onStreamComplete);
     }
 
     @Override
@@ -290,10 +301,10 @@ public class DefaultDifyClient extends DifyBaseClientImpl implements DifyClient 
         request.setResponseMode(ResponseMode.STREAMING);
 
         // 执行流式请求
-        executeStreamRequest(COMPLETION_MESSAGES_PATH, request, (line) -> processStreamLine(line, callback, CHAT_TERMINAL_EVENTS, (data, eventType) -> {
+        executeStreamRequest(COMPLETION_MESSAGES_PATH, request, (line) -> processStreamLineWithResult(line, callback, CHAT_TERMINAL_EVENTS, (data, eventType) -> {
             // 分发事件
             StreamEventDispatcher.dispatchCompletionEvent(callback, data);
-        }), callback::onException);
+        }), callback::onException, callback::onStreamComplete);
     }
 
     @Override
@@ -326,10 +337,10 @@ public class DefaultDifyClient extends DifyBaseClientImpl implements DifyClient 
         request.setResponseMode(ResponseMode.STREAMING);
 
         // 执行流式请求
-        executeStreamRequest(WORKFLOWS_RUN_PATH, request, (line) -> processStreamLine(line, callback, WORKFLOW_TERMINAL_EVENTS, (data, eventType) -> {
+        executeStreamRequest(WORKFLOWS_RUN_PATH, request, (line) -> processStreamLineWithResult(line, callback, WORKFLOW_TERMINAL_EVENTS, (data, eventType) -> {
             // 分发事件
             StreamEventDispatcher.dispatchWorkflowEvent(callback, data);
-        }), callback::onException);
+        }), callback::onException, callback::onStreamComplete);
     }
 
     @Override
@@ -408,9 +419,9 @@ public class DefaultDifyClient extends DifyBaseClientImpl implements DifyClient 
             params.put("continue_on_pause", continueOnPause);
         }
         String url = buildUrlWithParams(WORKFLOW_EVENTS_PATH + "/" + workflowRunId.trim() + "/events", params);
-        executeGetStreamRequest(url, (line) -> processStreamLine(line, callback, WORKFLOW_TERMINAL_EVENTS, (data, eventType) -> {
+        executeGetStreamRequest(url, (line) -> processStreamLineWithResult(line, callback, WORKFLOW_TERMINAL_EVENTS, (data, eventType) -> {
             StreamEventDispatcher.dispatchWorkflowEvent(callback, data);
-        }), callback::onException);
+        }), callback::onException, callback::onStreamComplete);
     }
 
     /**
@@ -553,5 +564,29 @@ public class DefaultDifyClient extends DifyBaseClientImpl implements DifyClient 
     private String getFileExtension(String fileName) {
         int lastDotIndex = fileName.lastIndexOf('.');
         return lastDotIndex > 0 ? fileName.substring(lastDotIndex + 1) : "";
+    }
+
+    /**
+     * 跟踪 Chatflow 的两个终止事件。
+     *
+     * <p>不同 Dify 版本可能以不同顺序发送 {@code message_end} 和
+     * {@code workflow_finished}。只有两者都收到时，客户端才主动停止读取；若连接先关闭，
+     * 则由通用的流结束回调处理。</p>
+     */
+    private static final class ChatflowTerminalState {
+        private boolean messageEndReceived;
+        private boolean workflowFinishedReceived;
+
+        private void record(String eventType) {
+            if (EventType.MESSAGE_END.getValue().equals(eventType)) {
+                messageEndReceived = true;
+            } else if (EventType.WORKFLOW_FINISHED.getValue().equals(eventType)) {
+                workflowFinishedReceived = true;
+            }
+        }
+
+        private boolean hasReceivedAllTerminalEvents() {
+            return messageEndReceived && workflowFinishedReceived;
+        }
     }
 }

--- a/src/main/java/io/github/imfangs/dify/client/impl/DefaultDifyDatasetsClient.java
+++ b/src/main/java/io/github/imfangs/dify/client/impl/DefaultDifyDatasetsClient.java
@@ -635,7 +635,7 @@ public class DefaultDifyDatasetsClient extends AbstractDifyClient implements Dif
     private static final String PIPELINE_DATASOURCE_NODES_PATH = "/pipeline/datasource/nodes";
     private static final String PIPELINE_RUN_PATH = "/pipeline/run";
     private static final String PIPELINE_FILE_UPLOAD_PATH = "/datasets/pipeline/file-upload";
-    private static final Set<EventType> PIPELINE_TERMINAL_EVENTS = EnumSet.of(EventType.WORKFLOW_FINISHED, EventType.ERROR);
+    private static final Set<EventType> PIPELINE_TERMINAL_EVENTS = EnumSet.of(EventType.WORKFLOW_FINISHED);
 
     @Override
     public List<DatasourcePluginResponse> listPipelineDatasourcePlugins(String datasetId, Boolean isPublished) throws IOException, DifyApiException {
@@ -676,9 +676,10 @@ public class DefaultDifyDatasetsClient extends AbstractDifyClient implements Dif
         log.debug("运行 Pipeline 数据源节点: datasetId={}, nodeId={}, request={}", datasetId, nodeId, request);
         String path = DATASETS_PATH + "/" + datasetId + PIPELINE_DATASOURCE_NODES_PATH + "/" + nodeId + "/run";
         executeStreamRequest(path, request,
-                (line) -> processStreamLine(line, callback, PIPELINE_TERMINAL_EVENTS,
+                (line) -> processStreamLineWithResult(line, callback, PIPELINE_TERMINAL_EVENTS,
                         (data, eventType) -> StreamEventDispatcher.dispatchWorkflowEvent(callback, data)),
-                callback::onException);
+                callback::onException,
+                callback::onStreamComplete);
     }
 
     @Override
@@ -719,9 +720,10 @@ public class DefaultDifyDatasetsClient extends AbstractDifyClient implements Dif
         log.debug("运行 Pipeline（流式模式）: datasetId={}", datasetId);
         String path = DATASETS_PATH + "/" + datasetId + PIPELINE_RUN_PATH;
         executeStreamRequest(path, request,
-                (line) -> processStreamLine(line, callback, PIPELINE_TERMINAL_EVENTS,
+                (line) -> processStreamLineWithResult(line, callback, PIPELINE_TERMINAL_EVENTS,
                         (data, eventType) -> StreamEventDispatcher.dispatchWorkflowEvent(callback, data)),
-                callback::onException);
+                callback::onException,
+                callback::onStreamComplete);
     }
 
     @Override

--- a/src/test/java/io/github/imfangs/dify/client/ChatflowStreamTerminalEventTest.java
+++ b/src/test/java/io/github/imfangs/dify/client/ChatflowStreamTerminalEventTest.java
@@ -1,0 +1,131 @@
+package io.github.imfangs.dify.client;
+
+import io.github.imfangs.dify.client.callback.ChatflowStreamCallback;
+import io.github.imfangs.dify.client.event.ErrorEvent;
+import io.github.imfangs.dify.client.event.MessageEndEvent;
+import io.github.imfangs.dify.client.event.WorkflowFinishedEvent;
+import io.github.imfangs.dify.client.impl.DefaultDifyClient;
+import io.github.imfangs.dify.client.model.chat.ChatMessage;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 验证 Chatflow 的终止事件顺序和连接关闭都能正确结束流处理。
+ */
+class ChatflowStreamTerminalEventTest {
+
+    @Test
+    void shouldDeliverBothTerminalEventsInDocumentedOrder() throws Exception {
+        assertTerminalEvents(
+                "data: {\"event\":\"message_end\",\"message_id\":\"message-1\",\"conversation_id\":\"conversation-1\",\"metadata\":{}}\n\n"
+                        + "data: {\"event\":\"workflow_finished\",\"data\":{\"id\":\"workflow-1\",\"status\":\"succeeded\"}}\n\n",
+                Arrays.asList("message_end", "workflow_finished", "stream_complete"));
+    }
+
+    @Test
+    void shouldDeliverBothTerminalEventsInReverseOrder() throws Exception {
+        assertTerminalEvents(
+                "data: {\"event\":\"workflow_finished\",\"data\":{\"id\":\"workflow-1\",\"status\":\"succeeded\"}}\n\n"
+                        + "data: {\"event\":\"message_end\",\"message_id\":\"message-1\",\"conversation_id\":\"conversation-1\",\"metadata\":{}}\n\n",
+                Arrays.asList("workflow_finished", "message_end", "stream_complete"));
+    }
+
+    @Test
+    void shouldNotifyCompletionWhenConnectionClosesBeforeAllTerminalEventsArrive() throws Exception {
+        CountDownLatch streamCompleted = new CountDownLatch(1);
+        DefaultDifyClient client = createClient(
+                "data: {\"event\":\"workflow_finished\",\"data\":{\"id\":\"workflow-1\",\"status\":\"succeeded\"}}\n\n");
+
+        client.sendChatMessageStream(ChatMessage.builder().query("test").user("tester").build(),
+                new ChatflowStreamCallback() {
+                    @Override
+                    public void onStreamComplete() {
+                        streamCompleted.countDown();
+                    }
+                });
+
+        assertTrue(streamCompleted.await(3, TimeUnit.SECONDS),
+                "未收到全部终止事件时，连接关闭仍应通知流读取结束");
+    }
+
+    @Test
+    void shouldNotNotifyCompletionAfterDifyErrorEvent() throws Exception {
+        CountDownLatch errorReceived = new CountDownLatch(1);
+        CountDownLatch streamCompleted = new CountDownLatch(1);
+        DefaultDifyClient client = createClient(
+                "data: {\"event\":\"error\",\"status\":400,\"code\":\"invalid_param\",\"message\":\"invalid request\"}\n\n");
+
+        client.sendChatMessageStream(ChatMessage.builder().query("test").user("tester").build(),
+                new ChatflowStreamCallback() {
+                    @Override
+                    public void onError(ErrorEvent event) {
+                        errorReceived.countDown();
+                    }
+
+                    @Override
+                    public void onStreamComplete() {
+                        streamCompleted.countDown();
+                    }
+                });
+
+        assertTrue(errorReceived.await(3, TimeUnit.SECONDS), "应分发 Dify error 事件");
+        assertFalse(streamCompleted.await(300, TimeUnit.MILLISECONDS),
+                "Dify error 事件不应触发正常结束回调");
+    }
+
+    private DefaultDifyClient createClient(String events) {
+        OkHttpClient httpClient = new OkHttpClient.Builder()
+                .addInterceptor(chain -> new Response.Builder()
+                        .request(chain.request())
+                        .protocol(Protocol.HTTP_1_1)
+                        .code(200)
+                        .message("OK")
+                        .body(ResponseBody.create(MediaType.parse("text/event-stream"), events))
+                        .build())
+                .build();
+        return new DefaultDifyClient("http://dify.test", "test-key", httpClient);
+    }
+
+    private void assertTerminalEvents(String events, List<String> expectedEvents) throws Exception {
+        List<String> receivedEvents = Collections.synchronizedList(new ArrayList<String>());
+        CountDownLatch streamCompleted = new CountDownLatch(1);
+        DefaultDifyClient client = createClient(events);
+
+        client.sendChatMessageStream(ChatMessage.builder().query("test").user("tester").build(),
+                new ChatflowStreamCallback() {
+                    @Override
+                    public void onMessageEnd(MessageEndEvent event) {
+                        receivedEvents.add("message_end");
+                    }
+
+                    @Override
+                    public void onWorkflowFinished(WorkflowFinishedEvent event) {
+                        receivedEvents.add("workflow_finished");
+                    }
+
+                    @Override
+                    public void onStreamComplete() {
+                        receivedEvents.add("stream_complete");
+                        streamCompleted.countDown();
+                    }
+                });
+
+        assertTrue(streamCompleted.await(3, TimeUnit.SECONDS), "应在两个终止事件都收到后通知流结束");
+        assertEquals(expectedEvents, receivedEvents);
+    }
+}

--- a/src/test/java/io/github/imfangs/dify/client/PipelineStreamCompletionTest.java
+++ b/src/test/java/io/github/imfangs/dify/client/PipelineStreamCompletionTest.java
@@ -1,0 +1,83 @@
+package io.github.imfangs.dify.client;
+
+import io.github.imfangs.dify.client.callback.WorkflowStreamCallback;
+import io.github.imfangs.dify.client.event.WorkflowFinishedEvent;
+import io.github.imfangs.dify.client.impl.DefaultDifyDatasetsClient;
+import io.github.imfangs.dify.client.model.datasets.DatasourceNodeRunRequest;
+import io.github.imfangs.dify.client.model.datasets.PipelineRunRequest;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 验证知识库 Pipeline 流也会通知通用的流结束回调。
+ */
+class PipelineStreamCompletionTest {
+
+    private static final String WORKFLOW_FINISHED_EVENT =
+            "data: {\"event\":\"workflow_finished\",\"data\":{\"id\":\"workflow-1\",\"status\":\"succeeded\"}}\n\n";
+
+    @Test
+    void shouldNotifyCompletionForPipelineDatasourceNodeStream() throws Exception {
+        DefaultDifyDatasetsClient client = createClient();
+        AtomicBoolean workflowFinishedReceived = new AtomicBoolean();
+        CountDownLatch streamCompleted = new CountDownLatch(1);
+
+        client.runPipelineDatasourceNodeStream("dataset-1", "node-1",
+                DatasourceNodeRunRequest.builder().build(),
+                createCallback(workflowFinishedReceived, streamCompleted));
+
+        assertTrue(streamCompleted.await(3, TimeUnit.SECONDS), "数据源节点流结束时应通知完成回调");
+        assertTrue(workflowFinishedReceived.get(), "应先分发 workflow_finished 事件");
+    }
+
+    @Test
+    void shouldNotifyCompletionForPipelineStream() throws Exception {
+        DefaultDifyDatasetsClient client = createClient();
+        AtomicBoolean workflowFinishedReceived = new AtomicBoolean();
+        CountDownLatch streamCompleted = new CountDownLatch(1);
+
+        client.runPipelineStream("dataset-1", PipelineRunRequest.builder().build(),
+                createCallback(workflowFinishedReceived, streamCompleted));
+
+        assertTrue(streamCompleted.await(3, TimeUnit.SECONDS), "Pipeline 流结束时应通知完成回调");
+        assertTrue(workflowFinishedReceived.get(), "应先分发 workflow_finished 事件");
+    }
+
+    private WorkflowStreamCallback createCallback(AtomicBoolean workflowFinishedReceived,
+                                                  CountDownLatch streamCompleted) {
+        return new WorkflowStreamCallback() {
+            @Override
+            public void onWorkflowFinished(WorkflowFinishedEvent event) {
+                workflowFinishedReceived.set(true);
+            }
+
+            @Override
+            public void onStreamComplete() {
+                streamCompleted.countDown();
+            }
+        };
+    }
+
+    private DefaultDifyDatasetsClient createClient() {
+        OkHttpClient httpClient = new OkHttpClient.Builder()
+                .addInterceptor(chain -> new Response.Builder()
+                        .request(chain.request())
+                        .protocol(Protocol.HTTP_1_1)
+                        .code(200)
+                        .message("OK")
+                        .body(ResponseBody.create(MediaType.parse("text/event-stream"), WORKFLOW_FINISHED_EVENT))
+                        .build())
+                .build();
+        return new DefaultDifyDatasetsClient("http://dify.test", "test-key", httpClient);
+    }
+}

--- a/src/test/java/io/github/imfangs/dify/client/WorkflowEventsStreamCompletionTest.java
+++ b/src/test/java/io/github/imfangs/dify/client/WorkflowEventsStreamCompletionTest.java
@@ -1,0 +1,72 @@
+package io.github.imfangs.dify.client;
+
+import io.github.imfangs.dify.client.callback.WorkflowStreamCallback;
+import io.github.imfangs.dify.client.event.WorkflowFinishedEvent;
+import io.github.imfangs.dify.client.impl.DefaultDifyClient;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 验证工作流事件的 GET SSE 接口保留通用流结束回调。
+ */
+class WorkflowEventsStreamCompletionTest {
+
+    private static final String WORKFLOW_FINISHED_EVENT =
+            "data: {\"event\":\"workflow_finished\",\"data\":{\"id\":\"workflow-1\",\"status\":\"succeeded\"}}\n\n";
+
+    @Test
+    void shouldNotifyCompletionForWorkflowEventStream() throws Exception {
+        AtomicReference<Request> requestReference = new AtomicReference<Request>();
+        DefaultDifyClient client = createClient(requestReference);
+        AtomicBoolean workflowFinishedReceived = new AtomicBoolean();
+        CountDownLatch streamCompleted = new CountDownLatch(1);
+
+        client.streamWorkflowEvents("workflow-1", "tester", false, false,
+                new WorkflowStreamCallback() {
+                    @Override
+                    public void onWorkflowFinished(WorkflowFinishedEvent event) {
+                        workflowFinishedReceived.set(true);
+                    }
+
+                    @Override
+                    public void onStreamComplete() {
+                        streamCompleted.countDown();
+                    }
+                });
+
+        assertTrue(streamCompleted.await(3, TimeUnit.SECONDS), "工作流事件流结束时应通知完成回调");
+        assertTrue(workflowFinishedReceived.get(), "应先分发 workflow_finished 事件");
+        assertNotNull(requestReference.get(), "应发起工作流事件请求");
+        assertEquals("GET", requestReference.get().method(), "工作流事件接口必须使用 GET 请求");
+    }
+
+    private DefaultDifyClient createClient(AtomicReference<Request> requestReference) {
+        OkHttpClient httpClient = new OkHttpClient.Builder()
+                .addInterceptor(chain -> {
+                    requestReference.set(chain.request());
+                    return new Response.Builder()
+                            .request(chain.request())
+                            .protocol(Protocol.HTTP_1_1)
+                            .code(200)
+                            .message("OK")
+                            .body(ResponseBody.create(MediaType.parse("text/event-stream"), WORKFLOW_FINISHED_EVENT))
+                            .build();
+                })
+                .build();
+        return new DefaultDifyClient("http://dify.test", "test-key", httpClient);
+    }
+}


### PR DESCRIPTION
## Problem

Chatflow streams end with two terminal events, `message_end` and `workflow_finished`. Dify's streaming guide says they arrive in that order:

> `message_end` then `workflow_finished` (both arrive, in that order) for Chatflow apps

The current SDK treats the first terminal event as the end of the stream: it dispatches the event, then breaks out of the read loop and discards the rest of the SSE response. In the documented order that is harmless, because `workflow_finished` really is the last event. In real deployments the order is not guaranteed. When a Dify server sends `workflow_finished` first and `message_end` second, the SDK stops at `workflow_finished` and silently drops `message_end`.

Chatflow 流以 `message_end` 和 `workflow_finished` 两个终止事件结尾。Dify 官方文档定义它们的到达顺序为：先 `message_end`，后 `workflow_finished`。

当前 SDK 把遇到的第一个终止事件当作流的终点：分发该事件后立刻跳出读取循环，丢弃 SSE 响应中剩余的内容。在文档顺序下这没有问题，因为 `workflow_finished` 确实是最后一个事件；但真实部署不保证顺序。当 Dify 服务器先发 `workflow_finished`、再发 `message_end` 时，SDK 会在 `workflow_finished` 处停止读取，`message_end` 被静默丢弃。

## Why the code ended up this way

This is not a freshly invented design decision; it reflects three rounds of changes in this repo, none of which solved the underlying order problem:

- **#128** added “stop reading and close the connection on a terminal event” to make socket cleanup deterministic.
- **#140** observed that stopping at `workflow_finished` loses `message_end` in some deployments, and removed `workflow_finished` from the terminal set so reading continues until `message_end`.
- **#161** parameterized terminal events per app type and put Chatflow back on `WORKFLOW_TERMINAL_EVENTS` (stop at `workflow_finished`), which restored the documented-order behavior but re-introduced the loss of `message_end` in reverse-order deployments.

Each iteration chose one event as the single boundary, so each iteration is wrong for the other order. The two events are both terminal and their order is environmental, not contractual. Building the read loop around “stop at the first terminal event” cannot work for both orderings.

现状不是一次性的设计决策，而是本仓库三轮改动叠加的结果，没有一轮真正解决顺序问题：

- **#128** 引入“遇到终止事件即停止读取并关闭连接”，让 socket 清理行为确定。
- **#140** 观察到某些部署下在 `workflow_finished` 停止会丢失 `message_end`，于是把 `workflow_finished` 从终止事件集合中移除，继续读到 `message_end`。
- **#161** 按应用类型参数化终止事件，把 Chatflow 重新放回 `WORKFLOW_TERMINAL_EVENTS`（在 `workflow_finished` 停止），恢复了文档顺序下的行为，但重新引入了反序部署下 `message_end` 丢失的问题。

每一轮都只挑一个事件作为边界，所以每一轮在另一种顺序下都是错的。这两个事件都是终止事件，而它们的顺序取决于环境、不构成协议契约。把读取循环建立在“遇到第一个终止事件就停”之上，无法同时兼容两种顺序。

## Real-stream observation

A probe against a real Chatflow produced 343 events ending with:

```text
... -> workflow_finished (event 342) -> message_end (event 343)
```

The reverse of the documented order. With the current code, event 343 is never read.

对真实 Chatflow 做了一次探针，收到 343 个事件，结尾为：

```text
... -> workflow_finished（第 342 个）-> message_end（第 343 个）
```

与文档顺序相反。在当前代码下，第 343 个事件永远不会被读取。

## Solution

- Make the Chatflow read loop order-independent: track `message_end` and `workflow_finished` per stream, and stop reading only after both have been dispatched. If the connection reaches EOF first, EOF ends the read normally.
- Separate error handling from normal completion: a Dify `error` event or transport failure ends the stream through `onError` / `onException` and does not invoke the normal completion callback.
- Wire the normal completion callback into the other streaming entry points (chat, completion, workflow, workflow events, knowledge pipeline) so all streams share the same lifecycle contract.

- 让 Chatflow 读取循环与事件顺序无关：按流分别跟踪 `message_end` 与 `workflow_finished`，两个事件都分发后才停止读取；若连接先到达 EOF，则以 EOF 正常结束读取。
- 把错误处理与正常完成分开：Dify `error` 事件或传输层异常通过 `onError` / `onException` 结束流，不触发正常完成回调。
- 把正常完成回调接入其余流式入口（chat、completion、workflow、workflow events、knowledge pipeline），让所有流共享同一生命周期契约。

## Behavior after this change

| Stream outcome | Event callbacks | onStreamComplete |
| --- | --- | --- |
| Chatflow, both terminal events, any order | both delivered | yes |
| Chatflow, one terminal event, then EOF | delivered event is dispatched | yes, EOF fallback |
| Dify `error` event | `onError` | no |
| transport failure | `onException` | no |

`onStreamComplete` means the SDK has finished reading a non-error response; it does not assert that the business operation succeeded.

| 流结果 | 事件回调 | onStreamComplete |
| --- | --- | --- |
| Chatflow 两个终止事件都到达（任意顺序） | 两者都交付 | 是 |
| Chatflow 只到其中一个终止事件，随后 EOF | 已到达的事件照常分发 | 是，EOF 兜底 |
| Dify `error` 事件 | `onError` | 否 |
| 传输层异常 | `onException` | 否 |

`onStreamComplete` 表示 SDK 已读完非错误响应，不代表业务操作成功。

## Tests

In-memory SSE tests cover documented order, reverse order, EOF before both terminal events, error events not triggering completion, and completion on the remaining streaming entry points. All pass with `mvn -Dtest=ChatflowStreamTerminalEventTest,PipelineStreamCompletionTest,WorkflowEventsStreamCompletionTest test`.

内存 SSE 测试覆盖文档顺序、反序、两个终止事件到达前 EOF、error 事件不触发完成，以及其余流式入口的正常完成回调。`mvn -Dtest=ChatflowStreamTerminalEventTest,PipelineStreamCompletionTest,WorkflowEventsStreamCompletionTest test` 全部通过。
